### PR TITLE
paper-form enterToSubmit option

### DIFF
--- a/addon/components/paper-form.js
+++ b/addon/components/paper-form.js
@@ -15,6 +15,7 @@ const { Component, computed } = Ember;
 export default Component.extend(ParentMixin, {
   layout,
   tagName: '',
+  enterToSubmit: false,
   isValid: computed.not('isInvalid'),
   isInvalid: computed('childComponents.@each.isInvalid', function() {
     return this.get('childComponents').isAny('isInvalid');
@@ -24,6 +25,11 @@ export default Component.extend(ParentMixin, {
       if (this.get('lastIsValid') !== this.get('isValid')) {
         this.sendAction('onValidityChange', this.get('isValid'));
         this.set('lastIsValid', this.get('isValid'));
+      }
+    },
+    onInputSubmit() {
+      if(this.get('enterToSubmit')) {
+        this.send('onSubmit');
       }
     },
     onSubmit() {

--- a/addon/components/paper-form.js
+++ b/addon/components/paper-form.js
@@ -28,7 +28,7 @@ export default Component.extend(ParentMixin, {
       }
     },
     onInputSubmit() {
-      if(this.get('enterToSubmit')) {
+      if (this.get('enterToSubmit')) {
         this.send('onSubmit');
       }
     },

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -152,6 +152,12 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
       this.sendAction('onBlur', e);
       this.set('isTouched', true);
       this.notifyValidityChange();
+    },
+
+    handleKeyPress(e) {
+      if(e.keyCode === 13) {
+        this.sendAction('onInputSubmit');
+      }
     }
   }
 });

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -155,7 +155,7 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
     },
 
     handleKeyPress(e) {
-      if(e.keyCode === 13) {
+      if (e.keyCode === 13) {
         this.sendAction('onInputSubmit');
       }
     }

--- a/addon/templates/components/paper-form.hbs
+++ b/addon/templates/components/paper-form.hbs
@@ -4,6 +4,7 @@
   input=(component "paper-input"
     parentComponent=this
     onValidityChange=(action "onValidityChange")
+    onInputSubmit=(action "onInputSubmit")
   )
   submit-button=(component "paper-button"
     onClick=(action "onSubmit")
@@ -19,4 +20,3 @@
   )
   onSubmit=(action "onSubmit")
 )}}
-

--- a/addon/templates/components/paper-input.hbs
+++ b/addon/templates/components/paper-input.hbs
@@ -16,6 +16,7 @@
     onfocus={{onFocus}}
     onblur={{action "handleBlur"}}
     onkeydown={{onKeyDown}}
+    onkeypress={{action "handleKeyPress"}}
     oninput={{action "handleInput"}}
 
     name={{passThru.name}}
@@ -42,6 +43,7 @@
     onfocus={{onFocus}}
     onblur={{action "handleBlur"}}
     onkeydown={{onKeyDown}}
+    onkeypress={{action "handleKeyPress"}}
     oninput={{action "handleInput"}}
 
     accept={{passThru.accept}}


### PR DESCRIPTION
Triggers the `onSubmit` action when a user presses the enter key in an input field, if `enterToSubmit=true` is set on `paper-form`. This replicates expected html form behavior.

Of course, this only works when using the contextual `form.input` component. It doesn't do anything for `paper-autocomplete` or `paper-select` right now. Implementing that gets complex, and I'm not sure that it would even be desired behavior.