### PR TITLE
Revert "paper-form enterToSubmit option"

### DIFF
--- a/addon/components/paper-form.js
+++ b/addon/components/paper-form.js
@@ -15,7 +15,6 @@ const { Component, computed } = Ember;
 export default Component.extend(ParentMixin, {
   layout,
   tagName: '',
-  enterToSubmit: false,
   isValid: computed.not('isInvalid'),
   isInvalid: computed('childComponents.@each.isInvalid', function() {
     return this.get('childComponents').isAny('isInvalid');
@@ -25,11 +24,6 @@ export default Component.extend(ParentMixin, {
       if (this.get('lastIsValid') !== this.get('isValid')) {
         this.sendAction('onValidityChange', this.get('isValid'));
         this.set('lastIsValid', this.get('isValid'));
-      }
-    },
-    onInputSubmit() {
-      if (this.get('enterToSubmit')) {
-        this.send('onSubmit');
       }
     },
     onSubmit() {

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -152,12 +152,6 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
       this.sendAction('onBlur', e);
       this.set('isTouched', true);
       this.notifyValidityChange();
-    },
-
-    handleKeyPress(e) {
-      if (e.keyCode === 13) {
-        this.sendAction('onInputSubmit');
-      }
     }
   }
 });

--- a/addon/templates/components/paper-form.hbs
+++ b/addon/templates/components/paper-form.hbs
@@ -4,7 +4,6 @@
   input=(component "paper-input"
     parentComponent=this
     onValidityChange=(action "onValidityChange")
-    onInputSubmit=(action "onInputSubmit")
   )
   submit-button=(component "paper-button"
     onClick=(action "onSubmit")
@@ -20,3 +19,4 @@
   )
   onSubmit=(action "onSubmit")
 )}}
+

--- a/addon/templates/components/paper-input.hbs
+++ b/addon/templates/components/paper-input.hbs
@@ -16,7 +16,6 @@
     onfocus={{onFocus}}
     onblur={{action "handleBlur"}}
     onkeydown={{onKeyDown}}
-    onkeypress={{action "handleKeyPress"}}
     oninput={{action "handleInput"}}
 
     name={{passThru.name}}
@@ -43,7 +42,6 @@
     onfocus={{onFocus}}
     onblur={{action "handleBlur"}}
     onkeydown={{onKeyDown}}
-    onkeypress={{action "handleKeyPress"}}
     oninput={{action "handleInput"}}
 
     accept={{passThru.accept}}


### PR DESCRIPTION
Reverts PartCycleTech/ember-paper#2

Ember paper is going to go a different direction to solve this problem - by using the actual `form` element. I'm going to try to implement it that way and actually PR into ember paper, rather than having us diverge significantly from the source.